### PR TITLE
Updates to README Usage instructions and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM osrf/ros:noetic-desktop-full
 
 COPY ./robot_ws /robot_ws
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 #RUN source /opt/ros/noetic/setup.bash not working
-RUN . /opt/ros/noetic/setup.sh
+RUN source /opt/ros/noetic/setup.bash
  
 RUN apt-get update && \
     apt-get install -y ros-noetic-moveit && \
     apt-get install ros-noetic-joint-trajectory-controller
 
 
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; cd robot_ws; catkin_make' 
+# Command sourced from https://answers.ros.org/question/312577/catkin_make-command-not-found-executing-by-a-dockerfile/
+WORKDIR "robot_ws/build"
+
+RUN source ../devel/setup.bash

--- a/README.md
+++ b/README.md
@@ -36,14 +36,10 @@ $ docker run -it \
 ```
 Inside the container :
 ```
-$ cd robot_ws
-$ catkin_make
-$ cd build
 $ source ../devel/setup.bash
 ```
 **To Run Palletizing simulation :**
 
-- Ensure you are in the `/build` directory
 ```
 $ roslaunch fanuc_r2000ic_moveit_config palletizzation.launch
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The code runs inside a Docker Container
 ## Usage
 ```
 $ git clone https://github.com/RG-sw/Gazebo_Fanuc_Grasp.git
-$ cd Gazebo_Fanuc_Grasp/robot_ws
+$ cd Gazebo_Fanuc_Grasp
 ```
 Build Container & Run it
 ```
@@ -36,10 +36,14 @@ $ docker run -it \
 ```
 Inside the container :
 ```
-$ cd Gazebo_Fanuc_Grasp/robot_ws
+$ cd robot_ws
 $ catkin_make
+$ cd build
+$ source ../devel/setup.bash
 ```
 **To Run Palletizing simulation :**
+
+- Ensure you are in the `/build` directory
 ```
 $ roslaunch fanuc_r2000ic_moveit_config palletizzation.launch
 ```


### PR DESCRIPTION
In order to get the docker container running, I had to do some troubleshooting and run some additional commands. 

First, I believe the paths in the README were incorrect, so I updated it to reflect the changes based on my own process.

System information:
- OS: Ubuntu-20.04 on WSL2 on Windows 11 machine
- Docker Version:    24.0.7

---

The second commit updates the Dockerfile to automate as much as possible, including the `catkin_make` command. However, I found I still needed to source the devel/setup.bash script manually to get roslaunch to recognize the parameters specified in the launch files.